### PR TITLE
Dev/ft/ring 28845 use uuids

### DIFF
--- a/lib/hdclient.js
+++ b/lib/hdclient.js
@@ -172,7 +172,8 @@ class HyperdriveClient {
               httpAgent: this.httpAgent,
               errorAgent: this.errorAgent,
               requestTimeoutMs: this.options.requestTimeoutMs,
-              uuidmapping: this.options.uuidmapping });
+              uuidmapping: this.options.uuidmapping,
+            });
     }
 
     /**
@@ -201,7 +202,8 @@ class HyperdriveClient {
               httpAgent: this.httpAgent,
               errorAgent: this.errorAgent,
               requestTimeoutMs: this.options.requestTimeoutMs,
-              uuidmapping: this.options.uuidmapping });
+              uuidmapping: this.options.uuidmapping,
+            });
     }
 
     /**
@@ -228,7 +230,8 @@ class HyperdriveClient {
               httpAgent: this.httpAgent,
               errorAgent: this.errorAgent,
               requestTimeoutMs: this.options.requestTimeoutMs,
-              uuidmapping: this.options.uuidmapping });
+              uuidmapping: this.options.uuidmapping,
+            });
     }
 
     /**

--- a/lib/hdclient.js
+++ b/lib/hdclient.js
@@ -1,5 +1,6 @@
 'use strict'; // eslint-disable-line strict
 
+const fs = require('fs');
 const http = require('http');
 const kafka = require('node-rdkafka');
 const werelogs = require('werelogs');
@@ -53,6 +54,7 @@ class HyperdriveClient {
         });
         this.setupLogging(opts.logApi);
         this.setupErrorAgent(opts.errorAgent.kafkaBrokers);
+        this.setupUuidMapping(opts.uuidmapping);
     }
 
     /**
@@ -106,6 +108,20 @@ class HyperdriveClient {
     }
 
     /**
+     * Load UUID -> host:port mapping
+     * Use passed object or load JSON file
+     *
+     * @param {String|Object} uuidmapping - Mapping UUID on host:port
+     * @return {undefined}
+     */
+    setupUuidMapping(uuidmapping) {
+        if (typeof(uuidmapping) === 'string') {
+            const loaded = fs.readFileSync(uuidmapping);
+            this.options.uuidmapping = JSON.parse(loaded);
+        }
+    }
+
+    /**
      * Free error agent resources: memory, connections, etc
      * @return {undefined}
      */
@@ -155,7 +171,8 @@ class HyperdriveClient {
               callback, size, inputStream,
               httpAgent: this.httpAgent,
               errorAgent: this.errorAgent,
-              requestTimeoutMs: this.options.requestTimeoutMs });
+              requestTimeoutMs: this.options.requestTimeoutMs,
+              uuidmapping: this.options.uuidmapping });
     }
 
     /**
@@ -183,7 +200,8 @@ class HyperdriveClient {
             { fragments, rawKey, range, callback, log,
               httpAgent: this.httpAgent,
               errorAgent: this.errorAgent,
-              requestTimeoutMs: this.options.requestTimeoutMs });
+              requestTimeoutMs: this.options.requestTimeoutMs,
+              uuidmapping: this.options.uuidmapping });
     }
 
     /**
@@ -209,7 +227,8 @@ class HyperdriveClient {
             { fragments, rawKey, callback, log,
               httpAgent: this.httpAgent,
               errorAgent: this.errorAgent,
-              requestTimeoutMs: this.options.requestTimeoutMs });
+              requestTimeoutMs: this.options.requestTimeoutMs,
+              uuidmapping: this.options.uuidmapping });
     }
 
     /**

--- a/lib/http_delete.js
+++ b/lib/http_delete.js
@@ -103,18 +103,19 @@ function _handleErrors(opContext, errorAgent, errorObj,
  * @param {Number} chunkId - Current chunk number
  * @param {Number} fragmenId - Current fragment number
  * @param {Number} requestTimeoutMs - Timeout of each sub-query
+ * @param {Map} uuidmapping Map UUIDS to hyperdrive endpoints (ip:port)
  * @return {undefined}
  */
 function fragmentDELETE(
     { httpAgent, errorAgent, opContext, callback,
-      chunkId, fragmentId, requestTimeoutMs }) {
+      chunkId, fragmentId, requestTimeoutMs, uuidmapping }) {
     const isData = fragmentId < opContext.fragments.nDataParts;
     const chunk = opContext.fragments.chunks[chunkId];
     const fragment = isData ? chunk.data[fragmentId] :
               chunk.coding[fragmentId - opContext.fragments.nDataParts];
-
     const reqContext = { opContext, chunkId, fragmentId };
-    const { hostname, port, key } = fragment;
+    const { uuid, key } = fragment;
+    const { hostname, port } = utils.resolveUUID(uuidmapping, uuid);
     const requestOptions = httpUtils.getCommonStoreRequestOptions(
         httpAgent, hostname, port, key);
 
@@ -162,10 +163,11 @@ function fragmentDELETE(
  *                 (refer to keyscheme.js for content)
  * @param {HyperdriveClient~deleteCallback} callback - Callback
  * @param {Number} requestTimeoutMs - Timeout of each sub-query
+ * @param {Object} uuidmapping Map UUIDS to hyperdrive endpoints (ip:port)
  * @return {Object} Operation context tracking everything
  */
 function doDELETE({ httpAgent, errorAgent, log, fragments, rawKey,
-                    callback, requestTimeoutMs }) {
+                    callback, requestTimeoutMs, uuidmapping }) {
     const opContext = httpUtils.makeOperationContext(fragments, rawKey, log);
 
     /* Send all at once */
@@ -173,7 +175,7 @@ function doDELETE({ httpAgent, errorAgent, log, fragments, rawKey,
         [...chunk.data, ...chunk.coding].forEach((fragment, fragmentId) => {
             fragmentDELETE(
                 { httpAgent, errorAgent, opContext, callback,
-                  chunkId, fragmentId, requestTimeoutMs });
+                  chunkId, fragmentId, requestTimeoutMs, uuidmapping });
         });
     });
 

--- a/lib/http_get.js
+++ b/lib/http_get.js
@@ -271,18 +271,20 @@ function _fragmentGETCb(reqContext, callback, errorAgent) {
  * @param {Number} fragmenId - Current fragment number
  * @param {Number} requestTimeoutMs - Timeout of each sub-query
  * @param {null|[Number]} range - HTTP range requested
+ * @param {Object} uuidmapping Map UUIDS to hyperdrive endpoints (ip:port)
  * @return {undefined}
  */
 function fragmentGET(
     { httpAgent, errorAgent, opContext, callback,
-      chunkId, fragmentId, requestTimeoutMs, range, args }) {
+      chunkId, fragmentId, requestTimeoutMs, range, uuidmapping, args }) {
     const isData = fragmentId < opContext.fragments.nDataParts;
     const chunk = opContext.fragments.chunks[chunkId];
     const fragment = isData ? chunk.data[fragmentId] :
               chunk.coding[fragmentId - opContext.fragments.nDataParts];
 
     const reqContext = { opContext, chunkId, fragmentId, args };
-    const { hostname, port, key } = fragment;
+    const { uuid, key } = fragment;
+    const { hostname, port } = utils.resolveUUID(uuidmapping, uuid);
     const requestOptions = httpUtils.getCommonStoreRequestOptions(
         httpAgent, hostname, port, key);
 
@@ -430,6 +432,7 @@ function chunkGET(multiplexedStream, chunkId, baseFragmentGETArgs) {
             requestTimeoutMs: baseFragmentGETArgs.requestTimeoutMs,
             httpAgent: baseFragmentGETArgs.httpAgent,
             errorAgent: baseFragmentGETArgs.errorAgent,
+            uuidmapping: baseFragmentGETArgs.uuidmapping,
             callback: reply => _chunkGETCb(
                 chunkId, reply, multiplexedStream, baseFragmentGETArgs),
         })
@@ -451,10 +454,11 @@ function chunkGET(multiplexedStream, chunkId, baseFragmentGETArgs) {
  * @param {Number [] | Undefined} range - Range (if any) with
  *                                        first element the start
  *                                        and the second element the end
+ * @param {Object} uuidmapping Map UUIDS to hyperdrive endpoints (ip:port)
  * @returns {Object} Operation context tracking everything
  */
 function doGET({ httpAgent, errorAgent, log, fragments, rawKey,
-                 callback, requestTimeoutMs, range }) {
+                 callback, requestTimeoutMs, range, uuidmapping }) {
     const opContext = httpUtils.makeOperationContext(fragments, rawKey, log);
     if (range && range[0] && fragments.size < range[0]) {
         const invRange = Error(`Invalid range: ${range}`);
@@ -465,7 +469,8 @@ function doGET({ httpAgent, errorAgent, log, fragments, rawKey,
 
     const multiplexedStream = new stream.PassThrough();
     const baseFragmentGETArgs = {
-        httpAgent, errorAgent, opContext, callback, requestTimeoutMs, range };
+        httpAgent, errorAgent, opContext, callback,
+        requestTimeoutMs, range, uuidmapping };
     chunkGET(multiplexedStream, 0 /* starting chunk */, baseFragmentGETArgs);
 
     return opContext;

--- a/lib/http_put.js
+++ b/lib/http_put.js
@@ -210,7 +210,8 @@ function fragmentPUT(size, fragmentId, args) {
     const fragment = isData ? chunk.data[fragmentId] :
               chunk.coding[fragmentId - opContext.fragments.nDataParts];
 
-    const { hostname, port, key } = fragment;
+    const { uuid, key } = fragment;
+    const { hostname, port } = utils.resolveUUID(args.uuidmapping, uuid);
     const contentType = protocol.helpers.makePutContentType(
         { data: size } /* Only 'data' payload is supported */
     );
@@ -263,10 +264,11 @@ function fragmentPUT(size, fragmentId, args) {
  * @param {Number} requestTimeoutMs - Timeout of each sub-query
  * @param {Number} size - Stream length
  * @param {stream.Readable} inputStream - Stream to store
+ * @param {Object} uuidmapping Map UUIDS to hyperdrive endpoints (ip:port)
  * @returns {Object} Operation context tracking everything
  */
 function doPUT({ httpAgent, errorAgent, log, fragments, rawKey,
-                 callback, requestTimeoutMs, size, inputStream }) {
+                 callback, requestTimeoutMs, size, inputStream, uuidmapping }) {
     const opContext = httpUtils.makeOperationContext(fragments, rawKey, log);
     let demux = null;
     switch (fragments.code) {
@@ -288,7 +290,7 @@ function doPUT({ httpAgent, errorAgent, log, fragments, rawKey,
                 chunkStream, chunkSize, opContext,
                 fragmentPUT,
                 { opContext, chunkId, httpAgent, errorAgent,
-                  callback, requestTimeoutMs })
+                  callback, requestTimeoutMs, uuidmapping })
         ,
         opContext);
 

--- a/lib/http_utils.js
+++ b/lib/http_utils.js
@@ -205,7 +205,7 @@ function newRequest(options, logger, reqContext, timeoutMs, callback) {
     });
 
     // Socket inactivity timeout
-    request.timeoutTimerId = request.socket.setTimeout(
+    request.timerid = request.socket.setTimeout(
         timeoutMs,
         () => {
             let ret = null;

--- a/lib/keyscheme.js
+++ b/lib/keyscheme.js
@@ -141,18 +141,16 @@ function fragmentKeygen(prefix, rand, startOffset, layout, fragmentId) {
  * Helper function to create fragments
  *
  * @param {Object} context of all fragments
- * @param {String} location ip:port of destination
+ * @param {String} uuid of destination
  * @param {Number} startOffset inside the whole object (see split Design.md)
  * @param {String} layout Stringified replication policy
  * @param {Number} fragmentId position in the used code
  * @returns {Object} Generated fragment object
  */
-function makeFragment(context, location, startOffset, layout, fragmentId) {
-    const [hostname, port] = location.split(':');
+function makeFragment(context, uuid, startOffset, layout, fragmentId) {
     return {
         fragmentId,
-        hostname,
-        port: Number(port),
+        uuid,
         key: fragmentKeygen(context.objectKey, context.rand,
                             startOffset, layout, fragmentId),
     };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -75,9 +75,27 @@ function getChunkRange(fragments, chunkId, globalRange) {
     return { use: true, chunkRange: [cstart - start, cend - start] };
 }
 
+/**
+ * Resolve UUID into host:port
+ *
+ * @param {Object} uuidmapping - Map UUIDS to hyperdrive endpoints (ip:port)
+ * @param {String} uuid - UUID to resolve
+ * @return {null|Object} null on error, {hostname, port} on success
+ */
+function resolveUUID(uuidmapping, uuid) {
+    const match = uuidmapping[uuid];
+    if (match) {
+        const [hostname, port] = match.split(':');
+        return { hostname, port: Number(port) };
+    }
+
+    return null;
+}
+
 
 module.exports = {
     compareErrors,
     getChunkRange,
     range,
+    resolveUUID,
 };

--- a/tests/functional/test_put.js
+++ b/tests/functional/test_put.js
@@ -50,14 +50,13 @@ mocha.describe('PUT', function () {
                     assert.strictEqual(typeof rawKey, 'string');
                     const parts = hdclient.keyscheme.deserialize(rawKey);
 
-                    const [endpoint, port] =
-                              hdClient.options.policy.locations[0].split(':');
+                    const uuid =
+                              hdClient.options.policy.locations[0];
                     assert.strictEqual(parts.nDataParts, 1);
                     assert.strictEqual(parts.nCodingParts, 0);
                     assert.strictEqual(parts.nChunks, 1);
                     const fragment = parts.chunks[0].data[0];
-                    assert.strictEqual(fragment.hostname, endpoint);
-                    assert.strictEqual(fragment.port, Number(port));
+                    assert.strictEqual(fragment.uuid, uuid);
                     assert.ok(fragment.key, keyContext.objectKey);
 
                     /* Check cleanup mechanism */
@@ -101,14 +100,12 @@ mocha.describe('PUT', function () {
                     assert.strictEqual(typeof rawKey, 'string');
                     const parts = hdclient.keyscheme.deserialize(rawKey);
 
-                    const [endpoint, port] =
-                              hdClient.options.policy.locations[0].split(':');
+                    const uuid = hdClient.options.policy.locations[0];
                     assert.strictEqual(parts.nDataParts, 1);
                     assert.strictEqual(parts.nCodingParts, 0);
                     assert.strictEqual(parts.nChunks, 1);
                     const fragment = parts.chunks[0].data[0];
-                    assert.strictEqual(fragment.hostname, endpoint);
-                    assert.strictEqual(fragment.port, Number(port));
+                    assert.strictEqual(fragment.uuid, uuid);
                     assert.ok(fragment.key, keyContext.objectKey);
 
                     /* Check cleanup mechanism */
@@ -907,12 +904,10 @@ mocha.describe('PUT', function () {
 
                     /* Verify layout: fragment (i,j) sould be on hyperdrive i for all j */
                     for (let i = 0; i < 2; ++i) {
-                        const [endpoint, port] =
-                                  hdClient.options.policy.locations[i].split(':');
+                        const uuid = hdClient.options.policy.locations[i];
                         for (let j = 0; j < 3; ++j) {
                             const fragment = parts.chunks[j].data[i];
-                            assert.strictEqual(fragment.hostname, endpoint);
-                            assert.strictEqual(fragment.port, Number(port));
+                            assert.strictEqual(fragment.uuid, uuid);
                             assert.ok(fragment.key, keyContext.objectKey);
                         }
                     }


### PR DESCRIPTION
Currently targeting ecn branch until merged, eventually should target master directly.
hdclient now expects on startup a new parameter 'uuidmapping' containing either:
* a valid JS object (for test and script)
* a string pointing to a JSON file (evenutally available as a Kubernetes ConfigMap)
