### PR TITLE
Dev/ft/ring 28704 use arsenal-ish errors

### DIFF
--- a/lib/corruption_stream_checker.js
+++ b/lib/corruption_stream_checker.js
@@ -2,6 +2,8 @@
 
 const stream = require('stream');
 
+const utils = require('./utils');
+
 
 /** BIZOP protocol shenanigan
  *
@@ -50,16 +52,16 @@ class CorruptSafeStream extends stream.Transform {
      */
     _handleCorruption(actualCRC) {
         const opContext = this.reqContext.opContext;
-        opContext.log.error(
-            'Corrupted data',
-            { expectedCRC: this.expectedCRC, actualCRC });
-
-        const corruptedError = new Error('Corrupted data');
-        corruptedError.infos = {
-            status: 422,
+        const extraInfos = {
+            expectedCRC: this.expectedCRC,
+            actualCRC,
             method: 'GET',
+            chunkId: this.reqContext.chunkId,
+            fragmentId: this.reqContext.fragmentId,
         };
-
+        const corruptedError = utils.mockedArsenalError(
+            'CorruptedData', 422, 'Bad CRC', extraInfos);
+        opContext.log.error(corruptedError);
         const chunkStatus = opContext.status[this.reqContext.chunkId];
         const fragmentStatus = chunkStatus.statuses[this.reqContext.fragmentId];
         chunkStatus.nOk--;

--- a/lib/hdclient.js
+++ b/lib/hdclient.js
@@ -10,6 +10,7 @@ const keyscheme = require('./keyscheme');
 const httpGET = require('./http_get');
 const httpPUT = require('./http_put');
 const httpDELETE = require('./http_delete');
+const utils = require('./utils');
 
 
 class HyperdriveClient {
@@ -196,7 +197,10 @@ class HyperdriveClient {
         try {
             fragments = keyscheme.deserialize(rawKey);
         } catch (error) {
-            callback(error);
+            const enhancedError = utils.mockedArsenalError(
+                'ParseError', 400,
+                `Failed to parse input key: ${error.message}`);
+            callback(enhancedError);
             return null;
         }
 

--- a/lib/hdclient.js
+++ b/lib/hdclient.js
@@ -228,7 +228,10 @@ class HyperdriveClient {
         try {
             fragments = keyscheme.deserialize(rawKey);
         } catch (error) {
-            callback(error);
+            const enhancedError = utils.mockedArsenalError(
+                'ParseError', 400,
+                `Failed to parse input key: ${error.message}`);
+            callback(enhancedError);
             return null;
         }
 

--- a/lib/http_delete.js
+++ b/lib/http_delete.js
@@ -5,12 +5,8 @@ const httpUtils = require('./http_utils');
 const utils = require('./utils');
 
 function _isReplyBad(replyInfos) {
-    // Here error.infos stores HTTP return code as 'status'
-    // Will be fixed later on with proper Arsenal errors
-    // https://scality.atlassian.net/browse/RING-28704
     return (replyInfos.error &&
-            (!replyInfos.error.infos ||
-             replyInfos.error.infos.status !== 404));
+            replyInfos.error.code !== 404);
 }
 
 /**
@@ -80,16 +76,13 @@ function _handleErrors(opContext, errorAgent, errorObj,
             () => callback(currentError))
         .catch(
             // Return persistence error
-            // TODO: not sure this a proper HTTP error....
-            // TODO: must be a better way than disabling it
             err => {
-                /* eslint-disable no-param-reassign */
-                err.infos = { status: 500, method: 'GET' };
-                opContext.failedToPersist = true;
-                /* eslint-enable no-param-reassign */
-                opContext.log.error(
-                    'Failure to persist orphaned fragments', err);
-                callback(err);
+                const enhancedError = utils.mockedArsenalError(
+                    'InternalError',
+                    500,
+                    `Failed to persist orphaned fragments: ${err.message}`);
+                opContext.log.error(enhancedError);
+                callback(enhancedError);
             });
 }
 

--- a/lib/http_get.js
+++ b/lib/http_get.js
@@ -11,11 +11,11 @@ const { CorruptSafeStream } = require('./corruption_stream_checker');
 
 
 function _isReplyBad(status) {
-    if (!status.error || !status.error.infos) {
+    if (!status.error || !status.error.code) {
         return false;
     }
 
-    const httpCode = status.error.infos.status;
+    const httpCode = status.error.code;
     return httpCode === 404 ||
         httpCode === 422; /* Corrupted */
 }
@@ -79,16 +79,15 @@ function _handleErrors(opContext, errorAgent, errorObj,
             () => errorHandle(currentError))
         .catch(
             // Return persistence error
-            // TODO: not sure this a proper HTTP error....
-            // TODO: must be a better way than disabling it
             err => {
-                /* eslint-disable no-param-reassign */
-                err.infos = { status: 500, method: 'GET' };
+                // eslint-disable-next-line no-param-reassign
                 opContext.failedToPersist = true;
-                /* eslint-enable no-param-reassign */
-                opContext.log.error(
-                    'Failure to persist fragments to repair', err);
-                errorHandle(err);
+                const enhancedError = utils.mockedArsenalError(
+                    'InternalError',
+                    500,
+                    `Failed to persist fragments to repair: ${err.message}`);
+                opContext.log.error(enhancedError);
+                errorHandle(enhancedError);
             });
 }
 

--- a/lib/http_put.js
+++ b/lib/http_put.js
@@ -171,17 +171,14 @@ function _handleErrors(opContext, errorAgent, errorObj,
         ).catch(err => err));
     }
 
-    const handlePromiseError = error => {
+    const handlePromiseError = err => {
         /* Return persistence error */
-        // TODO: not sure this a proper HTTP error....
-        // TODO: must be a better way than disabling it
-        /* eslint-disable no-param-reassign */
-        error.infos = { status: 500, method: 'GET' };
-        opContext.failedToPersist = true;
-        /* eslint-enable no-param-reassign */
-        opContext.log.error(
-            'Failure to persist bad fragments fragments', error);
-        callback(error, opContext.rawKey);
+        const enhancedError = utils.mockedArsenalError(
+            'InternalError',
+            500,
+            `Failed to persist bad fragments: ${err.message}`);
+        opContext.log.error(enhancedError);
+        callback(enhancedError, opContext.rawKey);
     };
 
     Promise.all(promises).then(

--- a/lib/http_utils.js
+++ b/lib/http_utils.js
@@ -112,12 +112,16 @@ function _handleHttpSuccess(reqContext, callback, response) {
  *
  * @param {Object} reqContext to use
  * @param {function} callback opContext -> ?
+ * @param {http.Response} response - Received HTTP response
  * @param {Object} errInfos Extra information to attach on error
  * @returns {Any} Anything callback returned or null if not called
  */
-function _handleHttpError(reqContext, callback, errInfos) {
-    const error = new Error('HTTP request failed');
-    error.infos = errInfos;
+function _handleHttpError(reqContext, callback, response, errInfos) {
+    const error = utils.mockedArsenalError(
+        'InternalError',
+        response.statusCode,
+        'Request processing failed',
+        errInfos);
     if (_updateOperationContext(reqContext, { error })) {
         return callback(reqContext);
     }
@@ -147,12 +151,12 @@ function _createHttpRequest(options, logger, reqContext, callback) {
         const success = Math.floor(response.statusCode / 200);
         if (success !== 1) {
             const errInfos = {
-                status: response.statusCode,
                 headers: response.headers,
                 method: options.method,
             };
-            logger.error(`${response.method} ${response.url}:`, errInfos);
-            return _handleHttpError(reqContext, callback, errInfos);
+            logger.error(
+                `${response.method} ${response.url}: ${response.statusCode}`);
+            return _handleHttpError(reqContext, callback, response, errInfos);
         }
 
         return _handleHttpSuccess(reqContext, callback, response);
@@ -189,13 +193,9 @@ function newRequest(options, logger, reqContext, timeoutMs, callback) {
     request.on('error', error => {
         let ret = null;
         logger.error(error.message, enhanceLogs);
-        // TODO: avoid this hack?
-        /* eslint-disable no-param-reassign */
-        error.infos = enhanceLogs;
-        error.infos.status = 500; // HTTP return code
-        error.infos.method = options.method;
-        /* eslint-disable no-param-reassign */
-        if (_updateOperationContext(reqContext, { error })) {
+        const arsenalError = utils.mockedArsenalError(
+            `${options.method}Error`, 500, error.message);
+        if (_updateOperationContext(reqContext, { error: arsenalError })) {
             ret = callback(reqContext);
         }
         request.destroy();
@@ -208,10 +208,8 @@ function newRequest(options, logger, reqContext, timeoutMs, callback) {
         () => {
             let ret = null;
             logger.error('Timeout', enhanceLogs);
-            const error = new Error('Timeout');
-            error.infos = enhanceLogs;
-            error.infos.status = 500; // HTTP return code
-            error.infos.method = options.method;
+            const error = utils.mockedArsenalError(
+                'TimeoutError', 504, `No reply received in ${timeoutMs}ms`);
             if (_updateOperationContext(reqContext, { error, timeout: true })) {
                 ret = callback(reqContext);
                 request.abort();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,27 @@
  * regroup various helper code
  */
 
+
+/**
+ * Format an error into an Arsenal-compatible error object
+ *
+ * @param {String} type - Type of the error (must not contain spaces)
+ * @param {Number} code - Error code, very often a HTTP code
+ * @param {String} description - Error message to display
+ * @param {Object} additionalInfos - Any object to attach to the error
+ *
+ * @return {Error} A new Error object with addtional fields
+ *                 (code, description, type and infos)
+ */
+function mockedArsenalError(type, code, description, additionalInfos) {
+    const mockedError = new Error(type);
+    mockedError.infos = additionalInfos;
+    mockedError.code = code;
+    mockedError.description = description;
+    mockedError[type] = true;
+    return mockedError;
+}
+
 /**
  * Compare two HTTP errors
  *
@@ -94,6 +115,7 @@ function resolveUUID(uuidmapping, uuid) {
 
 
 module.exports = {
+    mockedArsenalError,
     compareErrors,
     getChunkRange,
     range,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,7 +44,7 @@ function compareErrors(lhs, rhs) {
         return -1;
     }
 
-    return lhs.infos.status - rhs.infos.status;
+    return lhs.code - rhs.code;
 }
 
 /**

--- a/tests/functional/test_http_internals.js
+++ b/tests/functional/test_http_internals.js
@@ -1,4 +1,5 @@
 'use strict'; // eslint-disable-line strict
+/* eslint-disable max-len */
 /* eslint-disable prefer-arrow-callback */ // Mocha recommends not using => func
 /* eslint-disable func-names */
 
@@ -26,11 +27,11 @@ mocha.describe('HTTP internals', function () {
         opts.method = 'GET';
         opts.path = '/jesuisunemiteenpullover';
         const noLog = { error() {} };
-        const expectedErrorMessage = 'something awful happened';
+        const expectedErrorDescription = 'something awful happened';
 
         nock(`http://${hdClient.options.policy.locations[0]}`)
             .get(opts.path)
-            .replyWithError(expectedErrorMessage);
+            .replyWithError(expectedErrorDescription);
 
         const opContext = hdclient.httpUtils.makeOperationContext(
             { nDataParts: 1, nCodingParts: 0, nChunks: 1 });
@@ -46,8 +47,10 @@ mocha.describe('HTTP internals', function () {
                 assert.ok(reqCtx.opContext.status[0].statuses[0].error);
                 const returnedError = reqCtx.opContext.status[0].
                           statuses[0].error;
-                assert.strictEqual(expectedErrorMessage,
-                                   returnedError.message);
+                assert.strictEqual(returnedError.message, 'GETError');
+                assert.strictEqual(returnedError.code, 500);
+                assert.strictEqual(expectedErrorDescription,
+                                   returnedError.description);
                 done();
             }).end();
     });
@@ -60,7 +63,6 @@ mocha.describe('HTTP internals', function () {
         opts.method = 'GET';
         opts.path = '/jesuisunemiteenpullover';
         const noLog = { error() {} };
-        const expectedErrorMessage = 'Timeout';
 
         nock(`http://${hdClient.options.policy.locations[0]}`)
             .get(opts.path)
@@ -83,8 +85,11 @@ mocha.describe('HTTP internals', function () {
                 assert.ok(reqCtx.opContext.status[0].statuses[0].error);
                 const returnedError = reqCtx.opContext.status[0]
                           .statuses[0].error;
-                assert.strictEqual(expectedErrorMessage,
-                                   returnedError.message);
+                assert.strictEqual(returnedError.message, 'TimeoutError');
+                assert.strictEqual(returnedError.code, 504);
+                assert.strictEqual(
+                    returnedError.description,
+                    `No reply received in ${hdClient.options.requestTimeoutMs}ms`);
                 done();
             }).end();
     });
@@ -119,6 +124,11 @@ mocha.describe('HTTP internals', function () {
                 assert.strictEqual(reqCtx.opContext.status[0].nError, 1);
                 assert.strictEqual(reqCtx.opContext.status[0].nOk, 0);
                 assert.ok(reqCtx.opContext.status[0].statuses[0].error);
+                const returnedError = reqCtx.opContext.status[0].
+                          statuses[0].error;
+                assert.strictEqual(returnedError.message, 'GETError');
+                assert.strictEqual(returnedError.code, 500);
+                assert.strictEqual(returnedError.description, 'socket hang up');
                 done();
             });
 

--- a/tests/functional/test_put.js
+++ b/tests/functional/test_put.js
@@ -156,7 +156,7 @@ mocha.describe('PUT', function () {
                         chkTopic, undefined);
 
                     /* Check for errors */
-                    assert.strictEqual(err.infos.status,
+                    assert.strictEqual(err.code,
                                        mocks[0][0].statusCode);
                     done();
                 });
@@ -202,7 +202,8 @@ mocha.describe('PUT', function () {
                         chkTopic, undefined);
 
                     /* Check for errors */
-                    assert.strictEqual(err.infos.status, 500);
+                    assert.strictEqual(err.code, 504);
+                    assert.strictEqual(err.message, 'TimeoutError');
                     done();
                 });
         });
@@ -306,7 +307,7 @@ mocha.describe('PUT', function () {
                     (err, rawKey) => {
                         /* Check for errors */
                         assert.ok(err);
-                        assert.strictEqual(err.infos.status, 500);
+                        assert.strictEqual(err.code, 500);
 
                         /* Key should still be valid */
                         assert.strictEqual(typeof rawKey, 'string');
@@ -371,7 +372,7 @@ mocha.describe('PUT', function () {
                     (err, rawKey) => {
                         /* Check for errors */
                         assert.ok(err);
-                        assert.strictEqual(err.infos.status, 500);
+                        assert.strictEqual(err.code, 500);
 
                         /* Key should still be valid */
                         assert.strictEqual(typeof rawKey, 'string');
@@ -511,7 +512,8 @@ mocha.describe('PUT', function () {
                     (err, rawKey) => {
                         /* Check for errors */
                         assert.ok(err);
-                        assert.strictEqual(err.infos.status, 500);
+                        assert.strictEqual(err.code, 504);
+                        assert.strictEqual(err.message, 'TimeoutError');
 
                         /* Key should still be valid */
                         assert.strictEqual(typeof rawKey, 'string');
@@ -738,7 +740,7 @@ mocha.describe('PUT', function () {
             };
 
             hdmock.mockPUT(hdClient.options, keyContext, mocks);
-            hdClient.errorAgent.nextError = new Error('Failed to queue');
+            hdClient.errorAgent.nextError = new Error('Broken by Design');
 
             hdClient.put(
                 content,
@@ -747,9 +749,12 @@ mocha.describe('PUT', function () {
                 (err, rawKey) => {
                     /* Check for errors */
                     assert.ok(err);
-                    assert.strictEqual(err.infos.status, 500);
-                    assert.strictEqual(err.message, 'Failed to queue');
-
+                    assert.strictEqual(err.code, 500);
+                    assert.strictEqual(err.message, 'InternalError');
+                    assert.strictEqual(
+                        err.description,
+                        'Failed to persist bad fragments: Broken by Design'
+                    );
                     /* Key should still be valid */
                     assert.strictEqual(typeof rawKey, 'string');
                     const parts = hdclient.keyscheme.deserialize(rawKey);
@@ -827,7 +832,9 @@ mocha.describe('PUT', function () {
 
                     /* Check for errors */
                     assert.ok(err);
-                    assert.strictEqual(err.message, 'My bad...');
+                    assert.strictEqual(err.code, 500);
+                    assert.strictEqual(err.message, 'PUTError');
+                    assert.strictEqual(err.description, 'My bad...');
                     done();
                 });
         });
@@ -993,7 +1000,7 @@ mocha.describe('PUT', function () {
                 keyContext, '1',
                 (err, rawKey) => {
                     assert.ok(err);
-                    assert.strictEqual(err.infos.status, 500);
+                    assert.strictEqual(err.code, 500);
 
                     /* Check cleanup mechanism - everything to be deleted (safe side) */
                     const delTopic = hdmock.getTopic(hdClient, deleteTopic);


### PR DESCRIPTION
I decided not to directly use scality/Arsenal erros: unnecessary dependency and imho with a poorly designed API. Anyway, error reporting is now enhanced to provide Arsenal's error-like fields to please CloudServer