### PR TITLE
RING-29369 All returned HTTP streams must be consumed

### DIFF
--- a/lib/http_delete.js
+++ b/lib/http_delete.js
@@ -123,6 +123,14 @@ function fragmentDELETE(
         /* callback */
         reqCtx => {
             const opCtx = reqCtx.opContext;
+            const chunkStatus = opCtx.status[reqContext.chunkId];
+            const status = chunkStatus.statuses[reqContext.fragmentId];
+
+            /* Resume input stream */
+            if (status.response) {
+                status.response.resume();
+            }
+
             /* Wait for all to answer */
             if (opCtx.nPending !== 0) {
                 return null;

--- a/lib/http_get.js
+++ b/lib/http_get.js
@@ -155,6 +155,9 @@ function _replicationGETCb(reqContext, callback, errorAgent) {
         const saferStream = getCorruptionCheckedStream(
             status.response, reqContext, errorAgent);
         ret = callback(saferStream);
+    } else if (chunkStatus.nOk > 1 && status.response) {
+        /* Unused received input streams must be consumed */
+        status.response.resume();
     }
 
     /* Wait for all fragments in the chunk to answer */
@@ -212,12 +215,16 @@ function _erasureGETCb(reqContext, callback, errorAgent) {
                   opContext.fragments.splitSize;
         const istreams = chunkStatus.statuses.map(st => st.response);
         const decodedStream = new stream.PassThrough();
-        ecstream.decode(decodedStream,
-                        chunkSize,
-                        istreams.slice(0, k),
-                        istreams.slice(k),
-                        opContext.fragments.stripeSize);
+        ecstream.decode(
+            decodedStream,
+            chunkSize,
+            istreams.slice(0, k),
+            istreams.slice(k),
+            opContext.fragments.stripeSize);
         ret = callback(decodedStream);
+    } else if (chunkStatus.nOk > k && status.response) {
+        /* Unused received input streams must be consumed */
+        status.response.resume();
     }
 
     /* Wait for all fragments in the chunk to answer

--- a/lib/http_put.js
+++ b/lib/http_put.js
@@ -231,6 +231,14 @@ function fragmentPUT(size, fragmentId, args) {
         /* callback */
         reqCtx => {
             const opCtx = reqCtx.opContext;
+            const chunkStatus = opCtx.status[reqContext.chunkId];
+            const status = chunkStatus.statuses[reqContext.fragmentId];
+
+            /* Resume input stream */
+            if (status.response) {
+                status.response.resume();
+            }
+
             /* Wait for all to answer */
             if (opCtx.nPending !== 0) {
                 return null;

--- a/lib/http_utils.js
+++ b/lib/http_utils.js
@@ -92,18 +92,6 @@ function _handleHttpSuccess(reqContext, callback, response) {
         ret = callback(reqContext);
     }
 
-    /* Very important!
-     * Stream is paused, we must consume it, otherwise
-     * socket is left as alive and is not reused.
-     *
-     * The callback should either:
-     * - be listening on 'data' to read the body
-     * - doing nothing to drain the socket
-     *
-     * TODO add specific test with very low maxSocket to verify if
-     *      they are correctly free
-     */
-    response.resume();
     return ret;
 }
 


### PR DESCRIPTION
Erasure coding and replication are not using
all fetched streams to answer the client. If
any of those unused stream is not consumed, it
eventually trigger a timeout and has unfortunate
consequences in upper CloudServer layer.
If CloudServer has not finished to answer (large file)
then the GET will fail (short read/corruption/connection closed, etc).