### PR TITLE
RING-28492 CloudServer backend API uses keyContext versionId field

### DIFF
--- a/lib/hdclient.js
+++ b/lib/hdclient.js
@@ -174,7 +174,8 @@ class HyperdriveClient {
      * @param {integer} size - size
      * @param {Object} keyContext - parameters for key generation
      * @param {string} keyContext.bucketName - name of the object's bucket
-     * @param {string} keyContext.objectKey: destination object key name
+     * @param {string} keyContext.objectKey - destination object key name
+     * @param {String|Number} keyContext.versionId - S3 version of the object
      * @param {string} keyContext.owner - owner of the object
      * @param {string} keyContext.namespace - namespace of the S3 request
      * @param {string} reqUids - The serialized request id

--- a/lib/keyscheme.js
+++ b/lib/keyscheme.js
@@ -83,7 +83,7 @@ class KeySchemeDeserializeError extends Error {
 */
 function keyhash(keyContext) {
     // eslint-disable-next-line max-len
-    const input = `${keyContext.bucketName}/${keyContext.objectKey}/${keyContext.version}`;
+    const input = `${keyContext.bucketName}/${keyContext.objectKey}/${keyContext.versionId}`;
     const buf = Buffer.from(input, 'utf-8');
     return xxhash.hash64(buf, 0x1, 'hex');
 }

--- a/tests/functional/test_delete.js
+++ b/tests/functional/test_delete.js
@@ -21,7 +21,7 @@ mocha.describe('DELETE', function () {
     const keyContext = {
         bucketName: 'testbucket',
         objectKey: 'best / Obj~Ever!',
-        version: 1,
+        versionId: 1,
     };
 
     mocha.describe('Single hyperdrive', function () {

--- a/tests/functional/test_get.js
+++ b/tests/functional/test_get.js
@@ -25,7 +25,7 @@ mocha.describe('Hyperdrive Client GET', function () {
     const keyContext = {
         bucketName: 'test bucket',
         objectKey: 'best / Obj~Ever!',
-        version: 1,
+        versionId: 1,
     };
 
     mocha.describe('Single hyperdrive', function () {

--- a/tests/functional/test_put.js
+++ b/tests/functional/test_put.js
@@ -26,7 +26,7 @@ mocha.describe('PUT', function () {
     const keyContext = {
         bucketName: 'testbucket',
         objectKey: 'best / :Obj~Ever!',
-        version: 1,
+        versionId: 1,
     };
 
 

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -286,7 +286,7 @@ function _mockPutRequest(serviceId, uuidmapping, uuid, keyContext, endOffset, fr
  * that enables you to know which are going to be contacted
  *
  * @param {HyperdriveClient} client Hyperdrive client instance
- * @param {Object} keyContext same as given to actual PUT { objectKey, bucketName, version }
+ * @param {Object} keyContext same as given to actual PUT { objectKey, bucketName, versionId }
  * @param {Number} size Total payload size
  * @param {[[Reply]]} repliess description
  * @comment each entry of replies must be an Object with:
@@ -416,7 +416,7 @@ function _mockGetRequest(uuidmapping,
  * It generates a rawKey (as if there was a PUT before).
  *
  * @param {HyperdriveClient} client Hyperdrive client instance
- * @param {Object} keyContext same as given to actual PUT { objectKey, bucketName, version }
+ * @param {Object} keyContext same as given to actual PUT { objectKey, bucketName, versionId }
  * @param {Number} objectSize Total object size
  * @param {[[Reply]]} repliess description
  * @comment each entry of replies must be an Object with:
@@ -524,7 +524,7 @@ function _mockDeleteRequest(uuidmapping, location, { statusCode, timeoutMs = 0 }
  * It generates a rawKey (as if there was a PUT before).
  *
  * @param {HyperdriveClient} client Hyperdrive client instance
- * @param {Object} keyContext same as given to actual PUT { objectKey, bucketName, version }
+ * @param {Object} keyContext same as given to actual PUT { objectKey, bucketName, versionId }
  * @param {Number} objectSize Total object size
  * @param {[[Reply]]} repliess description
  * @comment replies are organized:  [replies] per chunk


### PR DESCRIPTION
Digging through CloudServer code for an unrelated reason, I realized they were setting 'versionId' filed as input, not 'version' field.