### PR TITLE
RING-28300 Use cached-path-relative v1.0.2 (v1.0.0 had a vulnerabilit…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -844,6 +844,14 @@
         "util": "~0.10.1",
         "vm-browserify": "^1.0.0",
         "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "cached-path-relative": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
+          "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==",
+          "dev": true
+        }
       }
     },
     "browserify-aes": {


### PR DESCRIPTION
…y issue)