### PR TITLE
RING-29723 Store metadata on a PUT

### DIFF
--- a/docs/Design.rst
+++ b/docs/Design.rst
@@ -112,6 +112,15 @@ a straggler. Using the offset in the total object as the only discriminator betw
 same fragments of different chunks means we do not need a manifest to track them all:
 having only the split size and the toal size, we can recover all fragment keys.
 
+Each fragmeents will store in Hyperdrive index a samll blob of metadata. This blob,
+identical for each fragment, encodes object information we cannot infer using
+a single hyperdrive. It will be used by background task daemons to perform several
+actions, most notably filing network repair into Kafka (ECN). As per current design,
+it contains:
+
+* the whole content of <rep_policy> ie the code description
+* the list of selected hyperdrive UUIDs - be able to quickly find all related fragments
+
 **Example key:**
 
 1/ Small key: storing s3://fakebucket/obj1/11 of 32KB with RS2+1 (stripe: 4096) onto hd1, hd2 and hd3
@@ -121,6 +130,7 @@ Hyperdrive keys:
 #. 42-123456789-deadbeef-320000-0
 #. 42-123456789-deadbeef-320000-1
 #. 42-123456789-deadbeef-320000-2
+#. Metadata: RS,2,1,4096#hd1#hd3#hd2
 
 2/ Splitted key: storing s3://fakebucket/Large1/13 with RS2+1,4096 onto hd1, hd2 and hd3
 Key size: 64000, split_size: 49000, 2 parts on same hyperdrive (no conflict!)
@@ -128,6 +138,7 @@ Key size: 64000, split_size: 49000, 2 parts on same hyperdrive (no conflict!)
 Main key: 1#42#64000,49000#RS,2,1,4096#123456456#cafebabe#hd3#hd2#hd3
 Hyperdrive keys:
 
+* Metadata: RS,2,1,4096#hd3#hd2#hd3
 * On hd1: none
 * On hd2
 

--- a/lib/http_put.js
+++ b/lib/http_put.js
@@ -234,7 +234,7 @@ function fragmentPUTCb(reqContext, errorAgent, callback) {
 /**
  * PUT a single fragment
  *
- * @param {Nulber} size - Size of inputStream
+ * @param {Number} size - Size of inputStream
  * @param {Number} fragmentId - Position in fragment list
  * @param {Object} args - Bundle of various stuff
  * @return {http.ClientRequest} Request to stream on
@@ -249,9 +249,11 @@ function fragmentPUT(size, fragmentId, args) {
 
     const { uuid, key } = fragment;
     const { hostname, port } = utils.resolveUUID(args.uuidmapping, uuid);
+    const mdsize = opContext.fragments.metadata ?
+              opContext.fragments.metadata.length : null;
+    const contentLength = mdsize ? size + mdsize : size;
     const contentType = protocol.helpers.makePutContentType(
-        { data: size } /* Only 'data' payload is supported */
-    );
+        { data: size, meta: mdsize });
 
     const queryString = httpUtils.makeQueryString(
         { immutable, force });
@@ -260,7 +262,7 @@ function fragmentPUT(size, fragmentId, args) {
 
     requestOptions.method = 'PUT';
     requestOptions.headers = {
-        ['Content-Length']: size,
+        ['Content-Length']: contentLength,
         ['Content-Type']: contentType,
     };
 
@@ -268,6 +270,12 @@ function fragmentPUT(size, fragmentId, args) {
     const request = httpUtils.newRequest(
         requestOptions, opContext.log, reqContext, requestTimeoutMs,
         reqCtx => fragmentPUTCb(reqCtx, errorAgent, callback));
+
+    /* Write the metadata first */
+    if (opContext.fragments.metadata) {
+        request.write(opContext.fragments.metadata,
+                      null /* binary encoding */);
+    }
 
     return request;
 }

--- a/lib/keyscheme.js
+++ b/lib/keyscheme.js
@@ -150,6 +150,21 @@ function serialize(parts) {
 }
 
 /**
+ * Serialize information to be stored as metadata
+ *
+ * @param {Object} parts description. Refer to keygen
+ *                 for inside details
+ * @returns {String} Object metadata
+ */
+function serializeMetadata(parts) {
+    return [
+        serializeReplicationPolicySection(parts),
+        ...parts.dataLocations,
+        ...parts.codingLocations,
+    ].join(SECTION_SEPARATOR);
+}
+
+/**
  * Generate a hyperdrive key
  *
  * @param {Number} serviceId - ServiceId how key creator
@@ -248,6 +263,8 @@ function keygen(serviceId, policy, objectContext, size,
         codingLocations,
     };
 
+    parts.metadata = serializeMetadata(parts);
+
     parts.chunks = utils.range(nChunks).map(chunkid => {
         const endOffset = Math.min(size, splitSize * (chunkid + 1));
         const data = dataLocations.map(
@@ -329,6 +346,7 @@ function deserialize(rawKey) {
         throw new KeySchemeDeserializeError(msg);
     }
     const nChunks = Math.ceil(size / splitSize);
+    const metadata = [repPolicy, ...locations].join(SECTION_SEPARATOR);
 
     const parsed = {
         serviceId,
@@ -343,6 +361,7 @@ function deserialize(rawKey) {
         nChunks,
         dataLocations,
         codingLocations,
+        metadata,
     };
 
     parsed.chunks = utils.range(nChunks).map(chunkid => {

--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -69,6 +69,7 @@ const SUPPORTED_PAYLOAD_TYPES = ['data', 'usermeta', 'meta', 'crc'];
  * @param {Number} payload.usermeta Positive user metadata payload length
  * @param {Number} payload.meta Positive metadata payload length
  * @returns {String} Valid Content-Type string to use for PUT query
+ * @comment Order is fixed: meta, usermd, data
  */
 function makePutContentType({ data, usermeta, meta }) {
     const dataType = (data !== null && data !== undefined) ?
@@ -77,7 +78,7 @@ function makePutContentType({ data, usermeta, meta }) {
           `; usermeta=${usermeta}` : '';
     const metaType = (meta !== null && meta !== undefined) ?
           `; meta=${meta}` : '';
-    return HYPERDRIVE_APPLICATION.concat(dataType, usermetaType, metaType);
+    return HYPERDRIVE_APPLICATION.concat(metaType, usermetaType, dataType);
 }
 
 /**

--- a/tests/unit/test_keyscheme.js
+++ b/tests/unit/test_keyscheme.js
@@ -39,6 +39,7 @@ mocha.describe('Keyscheme', function () {
             assert.strictEqual(fragments.nChunks, 1);
             assert.strictEqual(fragments.size, split.DATA_ALIGN);
             assert.strictEqual(fragments.splitSize, split.DATA_ALIGN);
+            assert.strictEqual(typeof fragments.metadata, 'string');
 
             /* Verify each fragment */
             assert.strictEqual(fragments.chunks.length, 1);
@@ -96,6 +97,7 @@ mocha.describe('Keyscheme', function () {
             assert.strictEqual(fragments.nChunks, 3);
             assert.strictEqual(fragments.size, split.DATA_ALIGN * 8 + 1);
             assert.strictEqual(fragments.splitSize, split.DATA_ALIGN * 4);
+            assert.strictEqual(typeof fragments.metadata, 'string');
 
             /* Verify each fragment */
             assert.strictEqual(fragments.chunks.length, 3);

--- a/tests/unit/test_protocol.js
+++ b/tests/unit/test_protocol.js
@@ -110,7 +110,7 @@ mocha.describe('Hyperdrive Protocol Specification', function () {
         });
         mocha.it('Mixture', function (done) {
             // Usermd does not exists, it is usermeta
-            const expected = `${hdProto.specs.HYPERDRIVE_APPLICATION}; data=4096; usermeta=256; meta=11`;
+            const expected = `${hdProto.specs.HYPERDRIVE_APPLICATION}; meta=11; usermeta=256; data=4096`;
             const generated = hdProto.helpers.makePutContentType(
                 { usermeta: 256, data: 4096, meta: 11 }
             );


### PR DESCRIPTION
Metadata contains information we cannot compute
only from a single hyperdrive. It will be used
by background tasks to perform repairs over
network (ECN).

Stored information:
1/ replication policy section (code, #data, #coding, stripeSize)
2/ UUIDs of selected hyperdrives (later to be compressed)