### PR TITLE
HD-1600 Introducing release process

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,25 @@
+# Hdclient Release
+
+This document contains the steps to be followed to release
+the project hdclient.
+
+## Release Process
+
+To release hdclient:
+
+* Create a new branch: `git checkout -b feature/TICKET-123-release-x.y.z`
+* Update the `version` field on the [package.json] file on to the desired tag.
+* Commit your changes: `git commit -m "TICKET-123 release version $tag"`
+* Create a PR and merge the [package.json] change.
+* Checkout the change in the development branch:
+  1. `git checkout development/x.y`
+  1. `git pull`
+* Tag the repository using the same tag:
+  1. `git tag --annotate $tag`
+  1. `git push origin $tag`
+
+Note: You can also perform the last two steps through
+the [GitHub Release] UI.
+
+[package.json]: ./package.json
+[GitHub Release]: https://github.com/scality/hdclient/releases/new


### PR DESCRIPTION
Introducing release process for hdclient.

Once we follow the suggested steps to release hdclient mentioned in this PR we will have the benefit of:
* Have clear communication of our tags for hdclient, therefore clear reference when using them in other projects (currently using sha1)
* Easier way of tracking our versions used in the projects
* Allow automation to do some of the work for us: Dependabot bumping the version in our project to keep us up to date.

