### PR TITLE
PTFE-1955 setup development/1 branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=16"
   },
-  "version": "1.1.7",
+  "version": "1.2.0",
   "description": "Hyperdrive appliance client library",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
hdclient is serving as one of the first guinea pig to test Bert-E's new capability of handling `development/x` branches: [PTFE-428](https://scality.atlassian.net/browse/PTFE-428)

For those branches every next releases is considered to be a minor version bump instead of a minor version bump, therefore updating the `version` in the `package.json` file to `1.2.0`.

Couple of things that was done on the repo:
- `development/1` branch was created from the `development/1.1` branch.
- `development/1` was set as the default branch.

The `development/1.1` still exists and can continue to live as long as desired, or can be deleted as well if there's no need for it.


[PTFE-428]: https://scality.atlassian.net/browse/PTFE-428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ